### PR TITLE
Update container creation to match requirments for improved command logging by CTF-Watcher

### DIFF
--- a/src/docker_env.py
+++ b/src/docker_env.py
@@ -89,7 +89,14 @@ class Docker:
         self._check_image_existence(image_name=image)
 
         endpoint_config = EndpointConfig(version="1.44", ipv4_address=host_address)
-        try:
+        
+	volumes = {
+        	"/var/log/commands.log": {'bind': '/var/log/commands.log', 'mode': 'rw'}
+        	#"/path/to/host/private_file": {"bind": "/wazuh-agent/commands.log", "mode": "rw"}
+    	}
+	environment["ENV_CONTAINER_NAME"] = container_name
+
+	try:
             container = self.client.containers.run(
                 image,
                 detach=True,
@@ -109,6 +116,8 @@ class Docker:
                 memswap_limit=0,
                 restart_policy={"name": "always"},
                 cpu_quota=500000,
+		volumes=volumes,
+		command="sh -c 'service rsyslog restart'",
             )
             return container
         except APIError as e:


### PR DESCRIPTION
The create_container() fucntion in src/docker_env.py now additionaly features:
 - a volume bind from /var/log/commands.log:var/log/commands.log
 - an environment variable ENV_CONTAINER_NAME=container_name
 - command restarting rsyslog

This allows the CTF-Watcher to display the used bash commands in its Grafana visualisation.
Restarting ryslogs enables CTF-Watcher to continue supervising the container even after it is restarted.

This matches the CTF-Watchers requirements for improved supervising as described by its documentation:
https://github.com/EMCL-Research-ITSecLab/ctf-watcher/tree/main/WazuhAgent